### PR TITLE
タスク詳細モーダルにグラフを追加

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,5 +1,5 @@
 class Api::TasksController < ApplicationController
-  before_action :set_task, only: [:show, :update, :destroy]
+  before_action :set_task, only: [:show, :update, :destroy, :pomodoro_count]
   def index
     @tasks = current_user.tasks.all
     render json: @tasks
@@ -32,14 +32,14 @@ class Api::TasksController < ApplicationController
   end
 
   def pomodoro_count
-    pomodoros = []
+    fetch_pomodoro = []
     d = Time.zone.today
     pomodoro = @task.pomodoros.group("date(created_at)").count
     (0..6).each do |a|
-      pomodoros.push({day: d - a, count: pomodoro[d - a]})
+      fetch_pomodoro.push({day: d - a, count: pomodoro[d - a]})
     end
 
-    render json: pomodoros
+    render json: fetch_pomodoro
   end
 
   private

--- a/app/javascript/pages/task/components/TaskChart.vue
+++ b/app/javascript/pages/task/components/TaskChart.vue
@@ -22,9 +22,9 @@ export default {
           xAxes: [{
             ticks: {
               beginAtZero: true,
-              stepSize: 1,
+              stepSize: 2,
               min: 0,
-              max: 30
+              max: 20
             },
           }],
         }

--- a/app/javascript/pages/task/components/TaskDetailModal.vue
+++ b/app/javascript/pages/task/components/TaskDetailModal.vue
@@ -16,8 +16,11 @@
             {{ task.deadline}}
             <br>
             <TaskChart
-
+              v-if="loaded"
+              :labels="labels"
+              :datasets="datasets"
             />
+            <br>
             <button
               type="button"
               class="btn btn-secondary"
@@ -37,6 +40,11 @@
 import TaskChart from './TaskChart.vue'
 export default {
   name: "TaskDetailModal",
+  data() {
+    return {
+    loaded: false
+    }
+  },
   props: {
     task: {
       type: Object,
@@ -47,7 +55,7 @@ export default {
     TaskChart
   },
   mounted() {
-    this.$axios.get('/pomodoro/pomodoro_count')
+    this.$axios.get(`/tasks/${this.task.id}/pomodoro_count`)
     .then(res => {
       this.labels = res.data.map(pomodoros => pomodoros.day)
       this.datasets = res.data.map(pomodoros => pomodoros.count)

--- a/app/javascript/pages/user/UserChart.vue
+++ b/app/javascript/pages/user/UserChart.vue
@@ -22,7 +22,7 @@ export default {
           xAxes: [{
             ticks: {
               beginAtZero: true,
-              stepSize: 1,
+              stepSize: 5,
               min: 0,
               max: 30
             },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   root to: 'home#index'
 
   namespace :api do
-    resources :tasks
+    resources :tasks do
+      member do
+        get 'pomodoro_count'
+      end
+    end
     resources :users, only: :create
     resource :profile, only: %i[show update]
     resource :session, only: %i[create destroy]


### PR DESCRIPTION
- tasks_controllerにpomodoro_countメソッドを追加
- TasksDetailModalがmounted()された時にAPIを叩きデータを取得してモーダルにグラフを表示するように実装しました。