### PR TITLE
タイマーブロック表示機能とスタートボタンの非表示

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -4,7 +4,6 @@
     <div class="container">
       <router-view />
     </div>
-
     <TheFooter />
   </div>
 </template>
@@ -17,7 +16,7 @@ import TheFooter from './components/TheFooter';
 export default {
   components: {
     TheHeader,
-    TheFooter
+    TheFooter,
   }
 }
 </script>

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -30,20 +30,28 @@
             <b-dropdown-item href="#">FA</b-dropdown-item>
           </b-nav-item-dropdown>
 
-          <b-nav-item-dropdown right>
-            <!-- Using 'button-content' slot -->
-            <template #button-content>
-              <em>User</em>
-            </template>
-            <router-link
-              :to="{ name: 'ProfilePage' }"
-              tag="b-dropdown-item"
-              
-            >
-              Profile
-            </router-link>
-            <b-dropdown-item @click="logoutUser">Sign Out</b-dropdown-item>
+          <template v-if="!user">
+            <b-nav-item right>
+              <router-link
+                :to="{ name: 'LoginPage' }"
+                tag="em"
+              >
+              Login
+              </router-link>
+            </b-nav-item>
+          </template>
+          <template v-else>
+          <b-nav-item-dropdown right text="User">
+              <router-link
+                :to="{ name: 'ProfilePage' }"
+                tag="b-dropdown-item"
+                
+              >
+                Profile
+              </router-link>
+              <b-dropdown-item @click="logoutUser">Sign Out</b-dropdown-item>
           </b-nav-item-dropdown>
+          </template>
         </b-navbar-nav>
       </b-collapse>
     </b-navbar>
@@ -51,11 +59,17 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
+import { mapGetters, mapActions } from 'vuex';
 export default {
   name: 'TheHeader',
+  computed: {
+    ...mapGetters("users", ["user"])
+  },
+  created() {
+    this.fetchUser();
+  },
   methods: {
-    ...mapActions("users", ["logoutUser"])
+    ...mapActions("users", ["fetchUser", "logoutUser"])
   }
 }
 </script>

--- a/app/javascript/pages/task/components/TaskChart.vue
+++ b/app/javascript/pages/task/components/TaskChart.vue
@@ -22,9 +22,9 @@ export default {
           xAxes: [{
             ticks: {
               beginAtZero: true,
-              stepSize: 2,
+              stepSize: 5,
               min: 0,
-              max: 20
+              max: 30
             },
           }],
         }
@@ -41,7 +41,7 @@ export default {
           backgroundColor: "#f25287",
           datalabels: {
             color: 'black',
-            anchor: 'end',
+            anchor: 'center',
             formatter: function(value, context) {
               if (value >= 1) {
               return '合計 ' + (value * 25) + '分'

--- a/app/javascript/pages/task/components/TaskItem.vue
+++ b/app/javascript/pages/task/components/TaskItem.vue
@@ -7,8 +7,9 @@
         {{ task.status }}
         <h5 class="card-title">{{ task.title }}</h5>
         <p class="card-text">{{ task.deadline }}
-          <button class="btn btn-primary" v-if="task.status == 'todo'" @click="handleOpenDetailTaskModal(task)">詳細</button>
-          <button class="btn btn-secondary" v-if="task.status == 'todo'" @click="handleOpenPomodoroTimer(task)">スタート</button>
+          <button class="btn btn-primary" @click="handleOpenDetailTaskModal(task)">詳細</button>
+          <slot name="start-button">
+          </slot>
           <button class="btn btn-secondary" v-if="task.status == 'todo'" @click="handleOpenEditTaskModal(task)">編集</button>
           <button class="btn btn-danger" @click="handleDeleteTask(task)">削除</button>
         </p>
@@ -21,6 +22,11 @@
 <script>
 export default {
   name: 'TaskItem',
+  data() {
+    return {
+      visiblePomodoroStartButton: true
+    }
+  },
   props: {
     task: {
       type: Object,
@@ -28,9 +34,6 @@ export default {
     }
   },
   methods: {
-    handleOpenPomodoroTimer(task) {
-      this.$emit('handleOpenPomodoroTimer', this.task)
-    },
     changeTaskStatus(task) {
       this.$emit('changeTaskStatus', this.task)
     },
@@ -42,7 +45,8 @@ export default {
     },
     handleOpenDetailTaskModal(task) {
       this.$emit('handleOpenDetailTask', this.task)
-    }
+    },
   }
 }
 </script>
+

--- a/app/javascript/pages/task/components/TaskList.vue
+++ b/app/javascript/pages/task/components/TaskList.vue
@@ -16,7 +16,16 @@
       @deleteTask="deleteTask"
       @changeTaskStatus="changeTaskStatus"
       @handleOpenDetailTask="handleOpenDetailTask"
-      />
+      >
+        <template #start-button>
+          <button 
+          class="btn btn-secondary" 
+          v-if="task.status == 'todo' && visiblePomodoroStartButton"
+          @click="handleOpenPomodoroTimer(task)"
+          >スタート
+          </button>
+        </template>
+      </TaskItem>
       </template>
     </div>
   </div>
@@ -38,14 +47,20 @@ export default {
   },
   data() {
     return {
+      visiblePomodoroStartButton: true
     }
   },
   components: {
     TaskItem
   },
+  created() {
+    this.CloseStartPomodoroButton();
+  },
   methods: {
     handleOpenPomodoroTimer(task) {
       this.$emit('handleOpenPomodoroTimer', task);
+      localStorage.setItem("pomodoroTask", JSON.stringify(task));
+      this.visiblePomodoroStartButton = false
     },
     handleOpenTaskEditModal(task) {
       this.$emit('handleOpenTaskEditModal', task)
@@ -58,6 +73,14 @@ export default {
     },
     changeTaskStatus(task) {
       this.$emit('changeTaskStatus', task)
+    },
+    CloseStartPomodoroButton() {
+      if(localStorage.getItem('totalSeconds')) {
+        this.visiblePomodoroStartButton = false
+      }
+    },
+    OpenStartPomodoroButton() {
+      this.visiblePomodoroStartButton = true
     }
   }
 }

--- a/app/javascript/pages/task/components/timer/BreakTimer.vue
+++ b/app/javascript/pages/task/components/timer/BreakTimer.vue
@@ -1,13 +1,75 @@
 <template>
   <div>
-    <div class="progress">
-      <div class="progress-bar progress-bar-striped bg-warning" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">50%</div>
+    <div class="timer">
+      <span>休憩時間   </span>
+      <span id="minutes">{{ minutes }}</span>
+      <span id:="middle">:</span>
+      <span id="seconds">{{ seconds }}</span>
     </div>
   </div>
 </template>
 
 <script>
 export default {
-  name: "BreakTimerBlock"
+  name: "BreakTimerBlock",
+    data() {
+    return {
+      totalTime: 0,
+      timer: null
+    }
+  },
+  created() {
+    this.startTimer();
+    console.log(this.totalTime);
+  },
+  methods: {
+    fetchTime: function() {
+      if(localStorage.getItem('breakSeconds')) {
+        this.totalTime = parseInt(localStorage.getItem('breakSeconds'))
+      } else {
+        this.totalTime = 1 * 5
+      }
+    },
+    startTimer() {
+      this.fetchTime();
+      this.timer = setInterval(() => this.countdown(), 1000);
+    },
+    resetTimer() {
+      clearInterval(this.timer);
+    },
+    padTime(time) {
+      return (time < 10 ? "0" : "") + time;
+    },
+    closeBreakTimer() {
+      this.$emit('closeBreakTimer');
+    },
+    countdown() {
+      if(this.totalTime >= 1) {
+        this.totalTime--;
+        localStorage.breakSeconds = this.totalTime
+      } else {
+        this.totalTime = 0;
+        this.resetTimer();
+        this.closeBreakTimer();
+        localStorage.removeItem('breakSeconds')
+      }
+    },
+  },
+  computed: {
+    minutes: function() {
+      const minutes = Math.floor(this.totalTime / 60);
+      return this.padTime(minutes);
+    },
+    seconds: function() {
+      const seconds = this.totalTime - this.minutes * 60;
+      return this.padTime(seconds);
+    }
+  }
 }
 </script>
+
+<style scoped>
+  .timer{
+    background-color: pink;
+  }
+</style>

--- a/app/javascript/pages/task/components/timer/PomodoroTimer.vue
+++ b/app/javascript/pages/task/components/timer/PomodoroTimer.vue
@@ -1,11 +1,11 @@
 <template>
    <div>
-     <div class="modal" @click.self="handleCloseModal">
+     <div class="modal" @click.self="handleCloseModal(task)">
        <div class="modal-dialog">
          <div class="modal-content">
            <div class="modal-header">
              <h4 class="modal-title">{{ task.title }}</h4>
-             <button type="button" class="close" v-on:click="handleCloseModal">×</button>
+             <button type="button" class="close" v-on:click="handleCloseModal(task)">×</button>
            </div>
            <div class="modal-body">
              <div class="task-information">
@@ -46,21 +46,31 @@ export default {
   },
   data() {
     return {
-      totalTime: 1 * 5,
+      timer: null,
+      totalTime: 0,
       startButton: true,
       completeButton: false,
     }
   },
   created() {
     this.startTimer();
+    console.log(this.totalTime);
   },
   methods: {
+    fetchTime: function() {
+      if(localStorage.getItem('totalSeconds')) {
+        this.totalTime = parseInt(localStorage.getItem('totalSeconds'))
+      } else {
+        this.totalTime = 1 * 3
+      }
+    },
     startTimer() {
-      setInterval(() => this.countdown(), 1000);
+      this.fetchTime();
+      this.timer = setInterval(() => this.countdown(), 1000);
       this.startButton = false
     },
     resetTimer() {
-      clearInterval(() => this.countdown());
+      clearInterval(this.timer);
     },
     padTime(time) {
       return (time < 10 ? "0" : "") + time;
@@ -68,16 +78,19 @@ export default {
     countdown() {
       if(this.totalTime >= 1) {
         this.totalTime--;
+        localStorage.totalSeconds = this.totalTime
       } else {
         this.totalTime = 0;
         this.resetTimer();
         this.completeButton = true;
       }
     },
-    handleCloseModal() {
-      this.$emit('close-modal');
+    handleCloseModal(task) {
+      this.$emit('close-modal', this.task);
     },
     handleCreatePomodoro(task) {
+      localStorage.removeItem('totalSeconds'),
+      localStorage.removeItem('pomodoroTask'),
       this.$emit('createPomodoro', task)
     }
   },

--- a/app/javascript/pages/task/components/timer/PomodoroTimerBlock.vue
+++ b/app/javascript/pages/task/components/timer/PomodoroTimerBlock.vue
@@ -1,13 +1,79 @@
 <template>
   <div>
-    <div class="progress">
-      <div class="progress-bar progress-bar-striped bg-info" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100">50%</div>
+    <div class="timer">
+      <span>タスク実行中   </span>
+      <span id="minutes">{{ minutes }}</span>
+      <span id:="middle">:</span>
+      <span id="seconds">{{ seconds }}</span>
+      <button
+        class="btn btn-secondary"
+        @click="handleOpenPomodoroTimerModal(task)"
+      >タスク</button>
     </div>
   </div>
 </template>
 
 <script>
 export default {
-  name: "PomodoroTimerBlock"
+  name: "PomodoroTimerBlock",
+    data() {
+    return {
+      task: {},
+      totalTime: 0,
+      timer: null
+    }
+  },
+  created() {
+    this.startTimer();
+    this.task = JSON.parse(localStorage.getItem('pomodoroTask'))
+    console.log(this.task)
+  },
+  methods: {
+    fetchTime: function() {
+      if(localStorage.getItem('totalSeconds')) {
+        this.totalTime = parseInt(localStorage.getItem('totalSeconds'))
+      } else {
+        this.totalTime = 1 * 5
+      }
+    },
+    startTimer() {
+      this.fetchTime();
+      this.timer = setInterval(() => this.countdown(), 1000);
+    },
+    resetTimer() {
+      clearInterval(this.timer);
+    },
+    padTime(time) {
+      return (time < 10 ? "0" : "") + time;
+    },
+    countdown() {
+      if(this.totalTime >= 1) {
+        this.totalTime--;
+        localStorage.totalSeconds = this.totalTime
+      } else {
+        this.totalTime = 0;
+        this.resetTimer();
+      }
+    },
+    handleOpenPomodoroTimerModal(task) {
+      this.$emit('openPomodoroTimerModal', this.task)
+    }
+  },
+  computed: {
+    minutes: function() {
+      const minutes = Math.floor(this.totalTime / 60);
+      return this.padTime(minutes);
+    },
+    seconds: function() {
+      const seconds = this.totalTime - this.minutes * 60;
+      return this.padTime(seconds);
+    }
+  }
 }
 </script>
+
+<style scoped>
+  .timer{
+    background-color: greenyellow;
+  }
+</style>

--- a/app/javascript/pages/task/index.vue
+++ b/app/javascript/pages/task/index.vue
@@ -2,10 +2,13 @@
   <div>
     <PomodoroTimerBlock
     v-if="isVisiblePomodoroTimerBlock"
+    @openPomodoroTimerModal="handleOpenPomodoroTimerModal"
     >
     </PomodoroTimerBlock>
+
     <BreakTimerBlock
     v-if="isVisibleBreakTimerBlock"
+    @closeBreakTimer="closeBreakTimer"
     >
     </BreakTimerBlock>
 
@@ -24,6 +27,8 @@
       :tasks="todoTasks"
       @changeTaskStatus="updateTask"
       @deleteTask="handleDeleteTask"
+      @closePomodoroStartButton="handleCloseBreakTimerBlock"
+      ref="taskList"
     >
       <template #header>
         <div class="h4">
@@ -36,6 +41,7 @@
       task-list-id="done-list"
       @handleOpenPomodoroTimer="handleOpenPomodoroTimerModal"
       :tasks="doneTasks"
+      @handleOpenDetailTask="handleOpenDetailTask"
       @changeTaskStatus="updateTask"
       @deleteTask="handleDeleteTask"
     >
@@ -112,6 +118,7 @@ import TaskDetailModal from './components/TaskDetailModal.vue';
 import PomodoroTimerModal from './components/timer/PomodoroTimer.vue';
 import PomodoroTimerBlock from './components/timer/PomodoroTimerBlock.vue';
 import BreakTimerBlock from './components/timer/BreakTimer.vue';
+
 export default {
   name: 'TaskIndex',
   data() {
@@ -151,6 +158,8 @@ export default {
   },
   created() {
     this.fetchTasks();
+    this.startPomodoroBlock();
+    this.startBreakTimer();
   },
   methods: {
     ...mapActions("tasks", ["fetchTasks", "createTask", "updateTask", "deleteTask"]),
@@ -177,9 +186,12 @@ export default {
     handleOpenPomodoroTimerModal(task) {
       this.isVisiblePomodoroTimerModal = true;
       this.pomodoroTask = task
+      this.handleCloseBreakTimerBlock();
     },
-    handleClosePomodoroTimerModal() {
-      this.isVisiblePomodoroTimerModal = false
+    handleClosePomodoroTimerModal(task) {
+      this.startPomodoroBlock();
+      this.isVisiblePomodoroTimerModal = false;
+      this.pomodoroTask = task
     },
     async handleAddCreateTask(task) {
       try{
@@ -216,10 +228,35 @@ export default {
       .then(res => {
         console.log(res.data),
         this.handleClosePomodoroTimerModal();
+        this.closePomodoroBlock();
+        this.isVisibleBreakTimerBlock = true
+        this.$refs.taskList.OpenStartPomodoroButton();
       })
       .catch(err => console.log(err.status))
+    },
+    startBreakTimer() {
+      if(localStorage.getItem('breakSeconds')){
+        this.isVisibleBreakTimerBlock = true
+      }
+    },
+    closeBreakTimer() {
+      this.isVisibleBreakTimerBlock = false
+    },
+    startPomodoroBlock() {
+      if(localStorage.getItem('totalSeconds')){
+        this.isVisiblePomodoroTimerBlock = true
+      }
+    },
+    closePomodoroBlock() {
+      this.isVisiblePomodoroTimerBlock = false
+    },
+    handleCloseBreakTimerBlock() {
+      if(localStorage.getItem('breakSeconds')){
+        this.isVisibleBreakTimerBlock = false
+        localStorage.removeItem('breakSeconds')
+      }
     }
-  }
+  },
 }
 </script>
 

--- a/app/javascript/pages/user/ProfilePage.vue
+++ b/app/javascript/pages/user/ProfilePage.vue
@@ -1,5 +1,16 @@
 <template>
   <div>
+    <BreakTimerBlock
+    v-if="isVisibleBreakTimerBlock"
+    @closeBreakTimer="closeBreakTimer"
+    >
+    </BreakTimerBlock>
+
+    <PomodoroTimerBlock
+    v-if="isVisiblePomodoroTimerBlock"
+    >
+    </PomodoroTimerBlock>
+
     <h1>プロフィールページ</h1>
     <p>{{ user.name }}</p>
     <p>{{ user.email }}</p>
@@ -31,24 +42,33 @@
 <script>
 import { mapGetters, mapActions } from 'vuex';
 import UserEditModal from './UserEditModal.vue';
-import UserChart from './UserChart.vue'
+import UserChart from './UserChart.vue';
+import BreakTimerBlock from '../task/components/timer/BreakTimer.vue';
+import PomodoroTimerBlock from '../task/components/timer/PomodoroTimerBlock.vue';
+
 export default {
   name: 'ProfilePage',
   data() {
     return {
       isVisibleUserEditModal: false,
+      isVisibleBreakTimerBlock: false,
+      isVisiblePomodoroTimerBlock: false,
       loaded: false
     }
   },
   components: {
     UserEditModal,
-    UserChart
+    UserChart,
+    BreakTimerBlock,
+    PomodoroTimerBlock
   },
   computed: {
     ...mapGetters("users", ["user"])
   },
   created() {
-    this.fetchUser()
+    this.fetchUser(),
+    this.startPomodoroBlock()
+    this.startBreakTimer()
   },
   mounted() {
     this.$axios.get('/pomodoro/pomodoro_count')
@@ -76,7 +96,27 @@ export default {
       } catch(err) {
         console.log(err)
       }
-    }
+    },
+    startBreakTimer() {
+      if(localStorage.getItem('breakSeconds')){
+        this.isVisibleBreakTimerBlock = true
+      }
+    },
+    closeBreakTimer() {
+      this.isVisibleBreakTimerBlock = false
+    },
+    startPomodoroBlock() {
+      if(localStorage.getItem('totalSeconds')){
+        this.isVisiblePomodoroTimerBlock = true
+      }
+    },
+    closePomodoroBlock() {
+      this.isVisiblePomodoroTimerBlock = false
+    },
+    handleOpenPomodoroTimerModal() {
+      this.isVisiblePomodoroTimerModal = true;
+      this.handleCloseBreakTimerBlock();
+    },
   }
 }
 </script>

--- a/app/javascript/pages/user/UserChart.vue
+++ b/app/javascript/pages/user/UserChart.vue
@@ -41,7 +41,7 @@ export default {
           backgroundColor: "#f25287",
           datalabels: {
             color: 'black',
-            anchor: 'end',
+            anchor: 'center',
             formatter: function(value, context) {
               if (value >= 1) {
               return '合計 ' + (value * 25) + '分'


### PR DESCRIPTION
- タイマースタート時、タスク一覧の上部にタイマーブロックを表示
- タイマーブロックにはポモドーロモーダルを再表示するボタンを追加
- タイマースタート時にタスクのスタートボタンを非表示
- ポモドーロ完了ボタンを押した後、休憩時間タイマーブロックがタスク一覧の上部に表示し、スタートボタンが再表示
- 休憩タイマーブロックは00:00になったと同時に非表示
- 休憩タイマー表示時にスタートボタンを押した場合、ポモドーロタイマー表示後に休憩タイマーは非表示になりポモドーロタイマーブロックが表示される。
- タスク一覧に表示されるポモドーロタイマーブロックと休憩タイマーブロックはプロフィールページにも表示されるように実装。
- プロフィールページではまだポモドーロモーダルは表示されていません。

- ヘッダーにログイン前・ログイン後の表示変更を追加。